### PR TITLE
Revert "fix tools manifest" and "point to planvtech repo"

### DIFF
--- a/tools/manifests/cva6-yocto.xml
+++ b/tools/manifests/cva6-yocto.xml
@@ -3,13 +3,13 @@
 <manifest>
   <remote name="openembedded" fetch="https://github.com/openembedded/" />
   <remote name="riscv" fetch="https://github.com/riscv/" />
-  <remote name="planvtech" fetch="https://github.com/planvtech/" />
+  <remote name="openhwgroup" fetch="https://github.com/openhwgroup/" />
   <default remote="openembedded" revision="master" />
 
   <project name="meta-riscv" remote="riscv" path="meta-riscv" revision="9fb725c93549849bcf5623325f6ac256fcd56e1e" />
   <project name="openembedded-core" remote="openembedded" path="openembedded-core" revision="ecb61b36938754cf925bf58aad3edf7346deced0" />
   <project name="bitbake" remote="openembedded" path="openembedded-core/bitbake" revision="1f06f326fa8b47e2a4dce756d57a9369a2225201" />
   <project name="meta-openembedded" remote="openembedded" path="meta-openembedded" revision="0d8dee917294c5529e9bb8d2dc31518bfe1c1252" />
-  <project name="meta-cva6-yocto" remote="planvtech" path="meta-cva6-yocto" revision="agilex7" />
+  <project name="meta-cva6-yocto" remote="openhwgroup" path="meta-cva6-yocto" revision="main" />
 
 </manifest>


### PR DESCRIPTION
Commit 927af502f8da ("point to planvtech repo") switched to planv's fork of this repository when using the repo tool for initial checkout. This should never haven been merged upstream. Commit d2f13d63d305 ("fix tools manifest") just fixed a whitspace.

This reverts commit d2f13d63d305 and commit 927af502f8da to switch back to the upstream repo in tools/manifests/cva6-yocto.xml again.


Tested-by: Angela Gonzalez <angela.gonzalez@planv.tech>